### PR TITLE
added no-conosle rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -28,6 +28,11 @@ module.exports = {
       'error',
       'always',
       { exceptAfterSingleLine: true }
-    ]
+    ], 
+
+    'no-console': [
+      'error', 
+      { allow: ['error', 'warn', 'info'] }
+    ],
   }
 };

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -28,11 +28,8 @@ module.exports = {
       'error',
       'always',
       { exceptAfterSingleLine: true }
-    ], 
-
-    'no-console': [
-      'error', 
-      { allow: ['error', 'warn', 'info'] }
     ],
+
+    'no-console': ['error', { allow: ['error', 'warn', 'info'] }]
   }
 };


### PR DESCRIPTION
## Description

Seems like in some of the updates the  of eslint, the config   `prettier::recommended` has been changed to not include the `no-console` rule by default.

We have been relying on that rule to catch debug  `console.log` messages. 
This PR adds the rule back disallowing `console.log` but allowing  `console.warn`, `console.info` and `console.error` methods