### PR TITLE
bug: remove usage of removed config from typescript eslint

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -13,7 +13,12 @@ module.exports = {
     indent: 'off',
     '@typescript-eslint/indent': 'off', // Prettier already takes care of this.
     '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/no-parameter-properties': 'error',
+    '@typescript-eslint/parameter-properties': [
+      true,
+      {
+        prefer: ['class-property']
+      }
+    ],
     '@typescript-eslint/no-unused-vars': [
       'error',
       {


### PR DESCRIPTION

## Description

bug: remove usage of removed config from typescript eslint