### PR TITLE
bug: allow projects to configure prettier using prettierrc

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const prettierrc = require('./.prettierrc.js');
-
 module.exports = {
   plugins: ['prettier'],
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
@@ -14,7 +12,7 @@ module.exports = {
     node: false
   },
   rules: {
-    'prettier/prettier': ['error', prettierrc],
+    'prettier/prettier': ['error', {}, { usePrettierrc: true }],
 
     quotes: [
       'error',


### PR DESCRIPTION


## Description

Before, we set the prettier config directly in eslint config, this prevents any overwrites in apps using this config. With this change, we now will use the prettierrc file in each consuming project.
